### PR TITLE
Use Day.js instead of process.hrtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: node_js
 
 node_js:
+  - "10.0.0"
   - "10.15.3"
 
 sudo: required
 
 install:
-  - npm ci
+  - npm install
 
 script:
   - npm test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # saseul.js - SASEUL Origin JavaScript Library
 
 ```
-npm ci
+npm install
 
 npm test
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const rmd160 = x => crypto.createHash('rmd160').update(x).digest('hex');
 
 const makePrivateKey = () => {
   const privateKey = crypto.randomBytes(24);
-  const time = process.hrtime.bigint().toString(16);
+  const time = dayjs().valueOf().toString(16);
   return toHex(privateKey) + pad(time, 16);
 };
 


### PR DESCRIPTION
Support web browsers and old version of `Node.js`.

Get `Unix Timestamp (milliseconds)` using `Day.js`.

Reference:
- Day.js API Reference - [Unix Timestamp (milliseconds) .valueOf()](https://github.com/iamkun/dayjs/blob/dev/docs/en/API-reference.md#unix-timestamp-milliseconds-valueof)