### PR TITLE
Add build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # saseul.js - SASEUL Origin JavaScript Library
 
-```
+[![Build Status](https://travis-ci.org/saseul/js-lib.svg?branch=master)](https://travis-ci.org/saseul/js-lib)
+
+```bash
+# Install the dependencies
 npm install
 
+# Run tests
 npm test
 
+# Lint and fix all
 npm run lint
 ```


### PR DESCRIPTION
Add `Travis CI` build status badge on `README.md` file.

Project pages on Travis CI: <https://travis-ci.org/saseul/js-lib>

Reference: [Embedding Status Images](https://docs.travis-ci.com/user/status-images/)

![screenshot](https://user-images.githubusercontent.com/36392/55134983-bb780180-516d-11e9-8825-403bc85c9ace.jpg)

